### PR TITLE
Utilise le fichier instantané au lieu du quotidien

### DIFF
--- a/prixCarburantClient/prixCarburantClient.py
+++ b/prixCarburantClient/prixCarburantClient.py
@@ -66,7 +66,7 @@ class PrixCarburantClient(object):
         
         price = {
             'valeur': str(valeur),
-            'maj': str(maj)
+            'maj': datetime.fromisoformat(str(maj)).isoformat() if maj else str(maj)
         }
         return price
 
@@ -142,7 +142,6 @@ class PrixCarburantClient(object):
             return True
 
     def load(self):
-        aDaybefore = datetime.today() - timedelta(days=1)
         try:
             self.downloadFile(
                  "https://static.data.gouv.fr/resources/prix-des-carburants-en-france/20181117-111538/active-stations.csv",

--- a/prixCarburantClient/prixCarburantClient.py
+++ b/prixCarburantClient/prixCarburantClient.py
@@ -62,7 +62,7 @@ class PrixCarburantClient(object):
         if valeur == 0:
             valeur = None
         else:
-            valeur = float(valeur) / 1000
+            valeur = float(valeur)
         
         price = {
             'valeur': str(valeur),
@@ -148,11 +148,10 @@ class PrixCarburantClient(object):
                  "https://static.data.gouv.fr/resources/prix-des-carburants-en-france/20181117-111538/active-stations.csv",
                  "station.csv")
             self.stations = self.loadStation('station.csv')
-            self.downloadFile("https://donnees.roulez-eco.fr/opendata/jour",
+            self.downloadFile("https://donnees.roulez-eco.fr/opendata/instantane",
                           "PrixCarburants_instantane.zip")
             self.unzipFile("PrixCarburants_instantane.zip", './PrixCarburantsData')
-            self.xmlData = "./PrixCarburantsData/PrixCarburants_quotidien_" + \
-                 aDaybefore.strftime("%Y%m%d") + ".xml"
+            self.xmlData = "./PrixCarburantsData/PrixCarburants_instantane.xml"
             self.stationsXML = self.decodeXML(self.xmlData)
             self.lastUpdate = datetime.today().date()
         except:


### PR DESCRIPTION
Les données provenant du endpoint `/jour` sont les données de la veille. 
En ces temps compliqué pour le carburant, les prix fluctuent souvent. 
Je propose donc d'utiliser le endpoint `/instantane` pour récupérer les données actuelles.
La différence entre les deux fichiers recus:
* Le nom du fichier dans le ZIP (logique)
* Les prix sont en €, et non en millième d'euro.

Je n'en ai pas vu d'autre... à priori.
